### PR TITLE
feat: fork/duplicate conversations from a message.

### DIFF
--- a/components/message.client.vue
+++ b/components/message.client.vue
@@ -9,7 +9,7 @@ const { isOnSharePage } = useSession()
 const element = ref()
 const isActionBarVisible = ref(false)
 
-const { clearErrorMessages, removeMessageFromConversation, currentConversation, updateConversationMessage } = useConversations()
+const { clearErrorMessages, removeMessageFromConversation, currentConversation, updateConversationMessage, forkConversation } = useConversations()
 
 // Action bar visibility
 function onClick() {
@@ -51,6 +51,19 @@ function onFavoriteMessage() {
             favorite: !isMessageFavorited.value,
         },
     })
+}
+
+const showForkConversationConfirmation = ref(false)
+async function onForkConversationContent() {
+    if (!currentConversation.value) {
+        return
+    }
+    await forkConversation(currentConversation.value?.id, props.message.id)
+
+    showForkConversationConfirmation.value = true
+    setTimeout(() => {
+        showForkConversationConfirmation.value = false
+    }, 1250)
 }
 
 const showCopyMessageConfirmation = ref(false)
@@ -189,6 +202,13 @@ function onCopyMessageContent() {
 
                         <GoButton
                             ml-auto
+                            secondary
+                            :icon="`${showForkConversationConfirmation ? 'i-tabler-check' : 'i-tabler-arrow-fork' } !text-10px sm:!text-16px` "
+                            :success="showForkConversationConfirmation"
+                            mr-3
+                            @click="onForkConversationContent"
+                        />
+                        <GoButton
                             secondary
                             :icon="`${showCopyMessageConfirmation ? 'i-tabler-check' : 'i-tabler-copy'} !text-10px sm:!text-16px` "
                             :success="showCopyMessageConfirmation"

--- a/composables/conversation.ts
+++ b/composables/conversation.ts
@@ -72,6 +72,34 @@ export const useConversations = () => {
         return newConversation
     }
 
+    async function cloneConversation(id: string, lastMessageId?: string, titlePrefix?: string) {
+        let titlePrefixWithDefault = titlePrefix || 'Copy: '
+        const originConversation = await getConversationById(id)
+        let lastIndex = -1
+        if (lastMessageId) {
+            lastIndex = originConversation.messages.findIndex((m: types.Message) => m.id === lastMessageId)
+        }
+        let messages = originConversation.messages
+        if (lastIndex !== 1) {
+            messages = originConversation.messages.slice(0, lastIndex + 1)
+        }
+        const newKey = await createConversation(
+            '',
+            {
+                ...originConversation,
+                id: nanoid(),
+                title: [titlePrefixWithDefault, originConversation.title].join(''),
+                messages,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            }
+        )
+    }
+
+    async function forkConversation(id: string, lastMessageId: string) {
+        await cloneConversation(id, lastMessageId, 'Fork: ')
+    }
+
     async function addMessageToConversation(id: string, message: ChatMessage) {
         const conversation = await db.table('conversations').get(id)
         if (!conversation) {
@@ -467,11 +495,13 @@ export const useConversations = () => {
     return {
         clearConversations,
         clearErrorMessages,
+        cloneConversation,
         conversationList,
         createConversation,
         currentConversation,
         deleteConversation,
         followupQuestions,
+        forkConversation,
         getConversationById,
         isTyping,
         isTypingInCurrentConversation,


### PR DESCRIPTION
Hi,

this PR adds a fork button next to the copy message button when a user clicks on a message.
This will then create a duplicate conversation up to that message, with the title: `Fork: < old title >`

What could be improved: Deduplicating `Fork: Fork: Fork: etc`. But it's a trivial thing to rename your conversation. So I figured that was out of scope.

This PR adds a function `cloneConversation()` in composables/conversation.ts. This function is called by `forkConversation()` in the same file. This way it's possible to easily extend with a "Copy Conversation" Button.

fixes #48 